### PR TITLE
Add remotes for bioc packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,7 +80,9 @@ Remotes:
     github::mikemc/speedyseq,
     github::adrientaudiere/lulu,
     github::david-barnett/microViz,
-    github::erocoar/gghalves
+    github::erocoar/gghalves,
+    bioc::release/phyloseq,
+    bioc::release/dada2
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 VignetteBuilder: knitr


### PR DESCRIPTION
Adding these bioc remotes makes it possible to just install `MiscMetabar` via

```r
devtools::install_github("adrientaudiere/MiscMetabar")
```

The additional block to manually install the Bioc packages is no longer required
```r
if (!require("BiocManager", quietly = TRUE)){
  install.packages("BiocManager")
}
BiocManager::install("dada2")
BiocManager::install("phyloseq")
```

Fix #38 